### PR TITLE
github actions-storybook CI/CD test

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,11 +11,20 @@ jobs:
     # The list of steps that the action will go through
     steps:
       - uses: actions/checkout@v1
-      - run: npm install -g pnpm
-        #👇 Adds Chromatic as a step in the workflow
-      - uses: chromaui/action@v1
-        # Options required for Chromatic's GitHub Action
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        id: pnpm-install
         with:
-          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/design-systems-for-developers/react/ko/review/ to obtain it
+          version: 8
+          run_install: false
+
+      #👇 Adds Chromatic as a step in the workflow
+      - name: Publish Chromatic
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          # Options required for Chromatic's GitHub Action
+          workingDir: packages/ui
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,6 +25,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           # Options required for Chromatic's GitHub Action
-          workingDir: packages/ui
+          workingDir: packages/ui/src
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,6 +19,10 @@ jobs:
           version: 8
           run_install: false
 
+      - name: Install Dependency
+        run: pnpm install -no-frozen-lockfile
+        working-directory: packages/ui
+
       #👇 Adds Chromatic as a step in the workflow
       - name: Publish Chromatic
         id: chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ jobs:
     # The list of steps that the action will go through
     steps:
       - uses: actions/checkout@v1
-      - run: pnpm
+      - run: npm install -g pnpm
         #👇 Adds Chromatic as a step in the workflow
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -25,6 +25,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           # Options required for Chromatic's GitHub Action
-          workingDir: packages/ui/src
+          workingDir: packages/ui
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ jobs:
     # The list of steps that the action will go through
     steps:
       - uses: actions/checkout@v1
-      - run: yarn
+      - run: pnpm
         #👇 Adds Chromatic as a step in the workflow
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "monorepo-turbo",
   "private": true,
   "scripts": {
+    "build-storybook": "turbo run build-storybook --filter=@repo/ui",
     "build": "turbo build",
     "dev": "turbo dev",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,8 @@
     "dev": "storybook dev -p 6006 --no-open",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-    "build-storybook": "storybook build --docs"
+    "build-storybook": "storybook build --docs",
+    "chromatic": "bash ./scripts/chromatic_publish.sh"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,8 +17,7 @@
     "dev": "storybook dev -p 6006 --no-open",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
-    "build-storybook": "storybook build --docs",
-    "release:storybook": "npx chromatic --project-token=<project-token>"
+    "build-storybook": "storybook build --docs"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "build-storybook": "storybook build --docs",
-    "chromatic": "bash ./scripts/chromatic_publish.sh"
+    "chromatic": "npx chromatic --exit-zero-on-changes -d storybook-static/"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",

--- a/packages/ui/scripts/chromatic_publish.sh
+++ b/packages/ui/scripts/chromatic_publish.sh
@@ -1,0 +1,2 @@
+CHROMATIC_PROJECT_TOKEN=$(grep CHROMATIC_PROJECT_TOKEN .env | cut -d "=" -f2)
+pnpm dlx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded --allow-console-errors

--- a/packages/ui/scripts/chromatic_publish.sh
+++ b/packages/ui/scripts/chromatic_publish.sh
@@ -1,2 +1,0 @@
-CHROMATIC_PROJECT_TOKEN=$(grep CHROMATIC_PROJECT_TOKEN .env | cut -d "=" -f2)
-npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded --allow-console-errors

--- a/packages/ui/scripts/chromatic_publish.sh
+++ b/packages/ui/scripts/chromatic_publish.sh
@@ -1,2 +1,2 @@
 CHROMATIC_PROJECT_TOKEN=$(grep CHROMATIC_PROJECT_TOKEN .env | cut -d "=" -f2)
-pnpm dlx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded --allow-console-errors
+npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded --allow-console-errors

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -13,7 +13,7 @@ export function Button({ children, className, appName }: ButtonProps): JSX.Eleme
     <button
       className={className}
       onClick={() => {
-        alert(`Hello from your ${appName} app!!!!!`);
+        alert(`Hello from your ${appName} app!!!!!!`);
       }}
       type="button"
     >

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -13,7 +13,7 @@ export function Button({ children, className, appName }: ButtonProps): JSX.Eleme
     <button
       className={className}
       onClick={() => {
-        alert(`Hello from your ${appName} app!`);
+        alert(`Hello from your ${appName} app!!!!!`);
       }}
       type="button"
     >

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -13,7 +13,7 @@ export function Button({ children, className, appName }: ButtonProps): JSX.Eleme
     <button
       className={className}
       onClick={() => {
-        alert(`Hello from your ${appName} app!!!!!!`);
+        alert(`Hello from your ${appName} app!!!!!!~`);
       }}
       type="button"
     >

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,7 @@
     "dev": {
       "cache": false,
       "persistent": true
-    }
+    },
+    "build-storybook": {}
   }
 }


### PR DESCRIPTION
# storybook CI/CD 설정

## 1. `.github/workflows/chromatic.yml` 작성 및 `packages/ui` CI/CD 스크립트 작성
  1. github repository secrets 환경변수 추가 (`secrets.CHROMATIC_PROJECT_TOKEN`은 secrets 환경변수로 등록해야한다. `secrets.GITHUB_TOKEN` 은 유저 정보 settings -> developer settings 에서 발급받은 class token임)
  2. `pnpm`을 사용하고 있으므로 CI/CD 환경에서도 `pnpm`을 사용할 수 있어야한다.
  3. 의존성 모듈을 설치해야한다.
  4. 이후 Chromatic에 publish 한다.

## 2. `chromatic` 빌드 명령어는 `build-storybook` 명령어 이후에 수행되어야하며 아래 2가지 방법 중 선택할 수 있음.
  1. `"chromatic": "npx chromatic --exit-zero-on-changes -d storybook-static/"` => [참고이슈](https://github.com/chromaui/chromatic-cli/issues/227)
  4. `"chromatic": "bash ./scripts/chromatic_publish.sh"` => 2번 방법의 경우 `scripts/chromatic_publish.sh` 쉘 파일을 만들고 `.env` 파일을 만들어야함. [참고 블로그](https://velog.io/@dmswl98/chromatic%EC%9C%BC%EB%A1%9C-storybook-%EB%B0%B0%ED%8F%AC%ED%95%98%EA%B8%B0with-monorepo-github-actions)